### PR TITLE
Add hardware control utilities to laptop hardware config

### DIFF
--- a/infrastructure/nixos/hosts/laptop/hardware-configuration.nix
+++ b/infrastructure/nixos/hosts/laptop/hardware-configuration.nix
@@ -44,4 +44,10 @@
 
   # Enable WiFi hardware
   hardware.enableRedistributableFirmware = true;
+
+  # Laptop hardware control utilities
+  environment.systemPackages = with pkgs; [
+    asusctl
+    supergfxctl
+  ];
 }


### PR DESCRIPTION
## Summary
- include ASUS laptop hardware control utilities in the laptop hardware configuration

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc4c851844832b9ab9c723b9556d14